### PR TITLE
fix: increase buildex setup timeout

### DIFF
--- a/.github/workflows/build-and-deploy-to-qa.yaml
+++ b/.github/workflows/build-and-deploy-to-qa.yaml
@@ -96,7 +96,7 @@ jobs:
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
-        timeout-minutes: 1
+        timeout-minutes: 2
 
       - name: Get commit details
         id: github-commit-details


### PR DESCRIPTION
Sometimes 1 minute is not enough to setup build, so it often timeout